### PR TITLE
feat(default.yaml): new shortcuts to toggle options

### DIFF
--- a/default.yaml
+++ b/default.yaml
@@ -1,7 +1,7 @@
 # Rime default settings
 # encoding: utf-8
 
-config_version: "0.37"
+config_version: "0.38"
 
 schema_list:
   - schema: luna_pinyin
@@ -136,8 +136,12 @@ key_binder:
     - { when: always, accept: Control+Shift+numbersign, toggle: full_shape }
     - { when: always, accept: Control+Shift+dollar, toggle: simplification }
     - { when: always, accept: Control+Shift+percent, toggle: extended_charset }
-    - { when: always, accept: Shift+space, toggle: full_shape }
+    - { when: always, accept: Control+Shift+space, toggle: .next }
+    - { when: always, accept: Shift+space, toggle: ascii_mode }
+    - { when: always, accept: Control+comma, toggle: full_shape }
     - { when: always, accept: Control+period, toggle: ascii_punct }
+    - { when: always, accept: Control+slash, toggle: simplification }
+    - { when: always, accept: Control+backslash, toggle: extended_charset }
 
 recognizer:
   patterns:


### PR DESCRIPTION
`Shift+space`: toggles `ascii_mode`  // not `Control+space` because it is a system shortcut, on some old systems
`Control+symbols[,./\]`: toggles other options...

*Pros*: easier to use than `Control+Shift+number`; `Shift+space` cannot be triggered by accident as 'Shift+Release' always does.
*Cons*: may conflict with some app shortcuts.